### PR TITLE
Quick Fixes

### DIFF
--- a/imessages-data-extract-and-prep.ipynb
+++ b/imessages-data-extract-and-prep.ipynb
@@ -166,7 +166,7 @@
    "outputs": [],
    "source": [
     "# save the combined table for ease of read for future analysis!\n",
-    "df_messages.to_csv('./imessages_high_sierra.csv', index = False)"
+    "df_messages.to_csv('./imessages_high_sierra.csv', index = False, encoding='utf-8')"
    ]
   },
   {

--- a/imessages-data-extract-and-prep.ipynb
+++ b/imessages-data-extract-and-prep.ipynb
@@ -90,10 +90,10 @@
     "# create pandas dataframe with all the tables you care about.\n",
     "\n",
     "## Mac OSX versions below High Sierra\n",
-    "#messages = pd.read_sql_query(\"select *, datetime(date/1000000000 + strftime(\"%s\", \"2001-01-01\") ,\"unixepoch\",\"localtime\")  as date_uct from message\", conn) \n",
+    "#messages = pd.read_sql_query(\"select *, datetime(date/1000000000 + strftime(\"%s\", \"2001-01-01\") ,\"unixepoch\",\"localtime\")  as date_utc from message\", conn) \n",
     "\n",
     "## High Sierra and above\n",
-    "messages = pd.read_sql_query('''select *, datetime(date/1000000000 + strftime(\"%s\", \"2001-01-01\") ,\"unixepoch\",\"localtime\")  as date_uct from message''', conn) \n",
+    "messages = pd.read_sql_query('''select *, datetime(date/1000000000 + strftime(\"%s\", \"2001-01-01\") ,\"unixepoch\",\"localtime\")  as date_utc from message''', conn) \n",
     "\n",
     "handles = pd.read_sql_query(\"select * from handle\", conn)\n",
     "chat_message_joins = pd.read_sql_query(\"select * from chat_message_join\", conn)"
@@ -113,7 +113,7 @@
    "source": [
     "# these fields are only for ease of datetime analysis (e.g., number of messages per month or year)\n",
     "messages['message_date'] = messages['date']\n",
-    "messages['timestamp'] = messages['date_est'].apply(lambda x: pd.Timestamp(x))\n",
+    "messages['timestamp'] = messages['date_utc'].apply(lambda x: pd.Timestamp(x))\n",
     "messages['date'] = messages['timestamp'].apply(lambda x: x.date())\n",
     "messages['month'] = messages['timestamp'].apply(lambda x: int(x.month))\n",
     "messages['year'] = messages['timestamp'].apply(lambda x: int(x.year))\n",

--- a/imessages-data-extract-and-prep.ipynb
+++ b/imessages-data-extract-and-prep.ipynb
@@ -154,7 +154,7 @@
     "\n",
     "\n",
     "print(len(df_messages))\n",
-    "#df_messages.head()\n"
+    "#print(df_messages.head())\n"
    ]
   },
   {

--- a/imessages-data-extract-and-prep.ipynb
+++ b/imessages-data-extract-and-prep.ipynb
@@ -150,7 +150,7 @@
     "merge_level_1 = pd.merge(messages[['text', 'handle_id', 'date','message_date' ,'timestamp', 'month','year','is_sent', 'message_id']],  handles[['handle_id', 'phone_number']], on ='handle_id', how='left')\n",
     "\n",
     "# and then that table with the chats\n",
-    "df_messages = pd.merge(temp, chat_message_joins[['chat_id', 'message_id']], on = 'message_id', how='left')\n",
+    "df_messages = pd.merge(merge_level_1, chat_message_joins[['chat_id', 'message_id']], on = 'message_id', how='left')\n",
     "\n",
     "\n",
     "print(len(df_messages))\n",


### PR DESCRIPTION
- Fix some typos for "UTC"
- Fix undeclared variable "temp" which was intended to be "merge_level_1"
- Make the call to df_messages.head() more useful by printing (else return value unused)
- Add utf-8 encoding when saving the dataframe to a csv as iMessages are extremely likely to contain non-ascii characters